### PR TITLE
Dont raise a KeyError when theres no request

### DIFF
--- a/sprockets/logging.py
+++ b/sprockets/logging.py
@@ -86,7 +86,7 @@ class JSONRequestFormatter(logging.Formatter):
             if not value:
                 del output[key]
         if 'message' in output:
-            del output['request']
+            output.pop('request', None)
         return json.dumps(output)
 
 


### PR DESCRIPTION
In some Tornado applications we make use of the `PeriodicCallback` mechanism which blows up the logger due to the lack of a `request`.
