### PR TITLE
tornado_log_function: Make work with Tornado 4.3.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`Next Release`_
+---------------
+- Updated ``tornado_log_function`` to work with Tornado 4.3.
+
 `1.3.2`_ Oct  2, 2015
 ---------------------
 - Switch to packaging as a package instead of a py_module.
@@ -39,6 +43,8 @@ Version History
 `1.0.0`_ Jun 09, 2015
 ---------------------
  - Added :class:`sprockets.logging.ContextFilter`
+
+.. _Next Release: https://github.com/sprockets/sprockets.logging/compare/1.3.2...master
 
 .. _1.3.2: https://github.com/sprockets/sprockets.logging/compare/1.3.1...1.3.2
 .. _1.3.1: https://github.com/sprockets/sprockets.logging/compare/1.3.0...1.3.1

--- a/sprockets/logging/__init__.py
+++ b/sprockets/logging/__init__.py
@@ -145,7 +145,7 @@ def tornado_log_function(handler):
                       handler.request.headers.get('Correlation-ID', None))
     log_method('', {'correlation_id': correlation_id,
                     'duration': 1000.0 * handler.request.request_time(),
-                    'headers': handler.request.headers,
+                    'headers': dict(handler.request.headers),
                     'method': handler.request.method,
                     'path': handler.request.path,
                     'protocol': handler.request.protocol,


### PR DESCRIPTION
Looks like HTTPHeaders changed a little:

```
TypeError: <tornado.httputil.HTTPHeaders object at 0x10cde5cc0> is not JSON serializable
```
